### PR TITLE
Don't use tabs for alignment in Javadoc

### DIFF
--- a/cyclops-sequence-api/src/main/java/com/aol/cyclops/sequence/SequenceM.java
+++ b/cyclops-sequence-api/src/main/java/com/aol/cyclops/sequence/SequenceM.java
@@ -250,9 +250,9 @@ public interface SequenceM<T> extends Unwrapable, Stream<T>, Seq<T>,Iterable<T>,
 	 * <pre>
 	 * {@code 
 	 *   List<Integer> list = SequenceM.of(1,2,2))
-	 * 										.cycle(Reducers.toCountInt(),3)
-	 * 										.collect(Collectors.toList());
-	 * 	//List[3,3,3];
+	 *                                 .cycle(Reducers.toCountInt(),3)
+	 *                                 .collect(Collectors.toList());
+	 *   //List[3,3,3];
 	 *   }
 	 * </pre>
 	 * 


### PR DESCRIPTION
You seem to use tabs in your source code and you seem to have set tabs to be equal to 2 spaces in your IDE. On Github, by default, tabs are equivalent to 8 spaces, in Eclipse, it is usually 4 spaces, so the rendering tends to be weird with default settings. See:
https://github.com/aol/cyclops/blob/b47d5170addfb61fd5704fb81a7e975290592bab/cyclops-sequence-api/src/main/java/com/aol/cyclops/sequence/SequenceM.java#L253

Tabs are OK for indentation (if you must :) ), but never for alignment.

I've fixed only one Javadoc, in case you don't agree :)