### PR TITLE
try-with-resources fixes

### DIFF
--- a/cyclops-try/src/main/java/com/aol/cyclops/trycatch/Try.java
+++ b/cyclops-try/src/main/java/com/aol/cyclops/trycatch/Try.java
@@ -321,17 +321,18 @@ public interface Try<T,X extends Throwable> extends Supplier<T>, ValueObject, To
 		private final CheckedFunction<V, T, X> catchBlock;
 		
 		private void invokeClose(Object in) {
-			if(in instanceof Iterable)
+			if(in instanceof Closeable || in instanceof AutoCloseable)
+				_invokeClose(in);
+			else if(in instanceof Iterable)
 				invokeClose((Iterable)in);
-			invokeClose((Closeable)in);
 		}
-		private void invokeClose(Iterable<Closeable> in){
-			for(Closeable next : in)
+		private void invokeClose(Iterable in){
+			for(Object next : in)
 				invokeClose(next);
 			
 		
 	}
-		private void invokeClose(Closeable in){
+		private void _invokeClose(Object in){
 			
 				Try.withCatch(()->in.getClass().getMethod("close")).filter(m->m!=null)
 						.flatMap(m->Try.withCatch(()->m.invoke(in))


### PR DESCRIPTION
1. Consider the following:

```java
Try
  .catchExceptions(IOException.class)
  .init(() -> SequenceM.fromStream(Files.lines(mypath)))
  .tryWithResources(lines -> lines.forEach(System.out::println)
```

MyFinallyBlock tries to iterate the already closed SequenceM (implements Iterable) again causing an exception.

2. Let's try to use a Stream instead of a SequenceM:

```java
Try
  .catchExceptions(IOException.class)
  .init(() -> Files.lines(mypath))
  .tryWithResources(lines -> lines.v1.forEach(System.out::println)
```

Currently, it fails too: Stream implements only AutoCloseable and not Closeable.
