### PR TITLE
Update to derive4j hkt 0.9.1

### DIFF
--- a/cyclops-higherkindedtypes/build.gradle
+++ b/cyclops-higherkindedtypes/build.gradle
@@ -44,7 +44,7 @@ configurations {
     }
 }
 dependencies {
-     compile group: 'org.derive4j.hkt', name: 'hkt', version: '0.9'
+     compile group: 'org.derive4j.hkt', name: 'hkt', version: '0.9.1'
 	provided group: 'org.projectlombok', name: 'lombok', version:lombokVersion
 
 	testCompile 'commons-io:commons-io:2.4'


### PR DESCRIPTION
Import fix in that release that prevent some classes
to be detected as hk-encoded.