### PR TITLE
Option.onEmpty support

### DIFF
--- a/cyclops/src/main/java/cyclops/control/Maybe.java
+++ b/cyclops/src/main/java/cyclops/control/Maybe.java
@@ -183,6 +183,11 @@ public interface Maybe<T> extends Option<T> {
         }
 
         @Override
+        public Maybe<T2> onEmpty(Runnable r) {
+            return maybe.onEmpty(r);
+        }
+
+        @Override
         public boolean isFailed() {
             return complete.isCompletedExceptionally();
         }
@@ -845,6 +850,8 @@ public interface Maybe<T> extends Option<T> {
     }
 
 
+    @Override
+    Maybe<T> onEmpty(Runnable r);
 
     @Override
     default Maybe<T> peek(final Consumer<? super T> c) {
@@ -886,6 +893,11 @@ public interface Maybe<T> extends Option<T> {
                     e3);
 
 
+        }
+
+        @Override
+        public Maybe<T> onEmpty(Runnable r) {
+            return this;
         }
 
         @Override
@@ -968,9 +980,7 @@ public interface Maybe<T> extends Option<T> {
             return m;
         }
 
-        /* (non-Javadoc)
-         * @see cyclops2.control.Maybe#recoverFlatMap(java.util.function.Supplier)
-         */
+
         @Override
         public Maybe<T> recoverWith(Supplier<? extends Option<T>> fn) {
             return this;
@@ -1098,6 +1108,11 @@ public interface Maybe<T> extends Option<T> {
         }
 
 
+        @Override
+        public Maybe<T> onEmpty(Runnable r){
+            return new Lazy<T>(
+                lazy.map(m -> m.onEmpty(r)));
+        }
         @Override
         public Maybe<T> recover(final T value) {
             return new Lazy<T>(
@@ -1231,6 +1246,14 @@ public interface Maybe<T> extends Option<T> {
         @Override
         public Maybe<T> filter(final Predicate<? super T> test) {
             return EMPTY;
+        }
+
+        @Override
+        public Maybe<T> onEmpty(Runnable r) {
+            return new Lazy<>(Eval.later(()->{
+                r.run();
+                return this;
+            }));
         }
 
 

--- a/cyclops/src/main/java/cyclops/control/Option.java
+++ b/cyclops/src/main/java/cyclops/control/Option.java
@@ -657,6 +657,14 @@ public interface Option<T> extends To<Option<T>>,
     }
 
 
+
+    default Option<T> onEmpty(Runnable r){
+        if(!isPresent()){
+            r.run();
+        }
+        return this;
+    }
+
     @Override
     default Option<T> peek(final Consumer<? super T> c) {
 

--- a/cyclops/src/test/java/cyclops/control/AbstractOptionTest.java
+++ b/cyclops/src/test/java/cyclops/control/AbstractOptionTest.java
@@ -1,0 +1,32 @@
+package cyclops.control;
+
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+public abstract class AbstractOptionTest extends AbstractValueTest {
+
+    protected  abstract  <T> Option<T> of(T value);
+    protected  abstract  <T> Option<T> empty();
+    protected  abstract  <T> Option<T> fromPublisher(Publisher<T> p);
+
+    boolean run;
+    @Test
+    public void whenEmpty_onEmpty_isRun(){
+        run = false;
+        empty().onEmpty(()->run=true)
+                .isPresent();
+        assertTrue(run);
+    }
+
+    @Test
+    public void whenNotEmpty_onEmpty_isNotRun(){
+        run = false;
+        of(10).onEmpty(()->run=true)
+            .isPresent();
+        assertFalse(run);
+    }
+
+}

--- a/cyclops/src/test/java/cyclops/control/AbstractValueTest.java
+++ b/cyclops/src/test/java/cyclops/control/AbstractValueTest.java
@@ -37,4 +37,6 @@ public abstract class AbstractValueTest {
     Assert.assertThat(capture.get(), equalTo(10));
   }
 
+
+
 }

--- a/cyclops/src/test/java/cyclops/control/MaybeTest.java
+++ b/cyclops/src/test/java/cyclops/control/MaybeTest.java
@@ -39,13 +39,14 @@ import static cyclops.data.tuple.Tuple.tuple;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.*;
 
-public class MaybeTest extends  AbstractValueTest implements Printable {
+public class MaybeTest extends  AbstractOptionTest implements Printable {
 
     Maybe<Integer> just;
     Maybe<Integer> none;
 
     @Before
     public void setUp() throws Exception {
+        lazy = true;
         just = Maybe.just(10);
         none = Maybe.nothing();
         cap =0;
@@ -53,6 +54,9 @@ public class MaybeTest extends  AbstractValueTest implements Printable {
     }
 
     int cap =0;
+
+
+    boolean lazy = true;
 
 
     @Test
@@ -190,7 +194,6 @@ public class MaybeTest extends  AbstractValueTest implements Printable {
         assertThat(just.recoverWith(()->Maybe.just(5)).toOptional().get(),equalTo(10));
     }
 
-    boolean lazy = true;
 
     @Test
     public void lazyTest() {
@@ -669,17 +672,17 @@ public class MaybeTest extends  AbstractValueTest implements Printable {
 	}
 
   @Override
-  protected <T> MonadicValue<T> of(T value) {
+  protected <T> Maybe<T> of(T value) {
     return Maybe.just(value);
   }
 
   @Override
-  protected <T> MonadicValue<T> empty() {
+  protected <T> Maybe<T> empty() {
     return Maybe.nothing();
   }
 
   @Override
-  protected <T> MonadicValue<T> fromPublisher(Publisher<T> p) {
+  protected <T> Maybe<T> fromPublisher(Publisher<T> p) {
     return Maybe.fromPublisher(p);
   }
 }

--- a/cyclops/src/test/java/cyclops/control/OptionTest.java
+++ b/cyclops/src/test/java/cyclops/control/OptionTest.java
@@ -32,7 +32,7 @@ import static cyclops.data.tuple.Tuple.tuple;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.*;
 
-public class OptionTest extends  AbstractValueTest implements Printable {
+public class OptionTest extends  AbstractOptionTest implements Printable {
 
     Option<Integer> eager;
     Option<Integer> none;
@@ -43,6 +43,9 @@ public class OptionTest extends  AbstractValueTest implements Printable {
         none = Option.none();
 
     }
+
+
+
     @Test
     public void fromNull(){
         System.out.println(Option.fromIterable(Seq.of().plus(null)));
@@ -521,17 +524,17 @@ public class OptionTest extends  AbstractValueTest implements Printable {
 	}
 
   @Override
-  protected <T> MonadicValue<T> of(T value) {
+  protected <T> Option<T> of(T value) {
     return Option.some(value);
   }
 
   @Override
-  protected <T> MonadicValue<T> empty() {
+  protected <T> Option<T> empty() {
     return Option.none();
   }
 
   @Override
-  protected <T> MonadicValue<T> fromPublisher(Publisher<T> p) {
+  protected <T> Option<T> fromPublisher(Publisher<T> p) {
     return Option.fromPublisher(p);
   }
 }


### PR DESCRIPTION
Impl for #1055

Implements onEmpty for Option and Maybe.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
