### PR TITLE
Reduce synchronization range in memozieSupplier(Memoize.java)

### DIFF
--- a/cyclops/src/main/java/cyclops/function/Memoize.java
+++ b/cyclops/src/main/java/cyclops/function/Memoize.java
@@ -36,7 +36,7 @@ public class Memoize {
         return ()->{
             Object val = value.get();
         if (val == UNSET) {
-            synchronized (UNSET){
+            synchronized (value){
                 if(value.get()==UNSET) {
                     val = s.get();
                     value.set(val);


### PR DESCRIPTION
synchronized on each 'value' rather than global 'UNSET'


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
