### PR TITLE
Rename Unwrapable to Unwrappable

### DIFF
--- a/cyclops-anym/src/main/java/com/oath/cyclops/anym/transformers/NonEmptyTransformer.java
+++ b/cyclops-anym/src/main/java/com/oath/cyclops/anym/transformers/NonEmptyTransformer.java
@@ -1,7 +1,7 @@
 package com.oath.cyclops.anym.transformers;
 
 import com.oath.cyclops.types.MonadicValue;
-import com.oath.cyclops.types.Unwrapable;
+import com.oath.cyclops.types.Unwrappable;
 import com.oath.cyclops.types.Value;
 import com.oath.cyclops.types.factory.Unit;
 import com.oath.cyclops.types.foldable.Folds;
@@ -17,7 +17,7 @@ import java.util.function.*;
 
 @Deprecated
 public abstract class NonEmptyTransformer<W extends WitnessType<W>,T> implements Publisher<T>,
-                                                                            Unwrapable,Transformable<T>,
+                                                                            Unwrappable,Transformable<T>,
                                                                             Unit<T>,
                                                                             Folds<T>{
 

--- a/cyclops-anym/src/main/java/com/oath/cyclops/anym/transformers/TransformerSeq.java
+++ b/cyclops-anym/src/main/java/com/oath/cyclops/anym/transformers/TransformerSeq.java
@@ -8,7 +8,7 @@ import java.util.stream.*;
 import com.oath.cyclops.types.persistent.PersistentCollection;
 import com.oath.cyclops.types.traversable.IterableX;
 import com.oath.cyclops.types.traversable.Traversable;
-import com.oath.cyclops.types.Unwrapable;
+import com.oath.cyclops.types.Unwrappable;
 import com.oath.cyclops.types.foldable.ConvertableSequence;
 import com.oath.cyclops.types.stream.ToStream;
 import cyclops.data.Seq;
@@ -28,7 +28,7 @@ import cyclops.companion.Streamable;
 import cyclops.monads.WitnessType;
 
 @Deprecated
-public interface TransformerSeq<W extends WitnessType<W>,T> extends Unwrapable,
+public interface TransformerSeq<W extends WitnessType<W>,T> extends Unwrappable,
                                                                     Traversable<T>,
                                                                     ToStream<T>,
                                                                     Publisher<T> {

--- a/cyclops-anym/src/main/java/com/oath/cyclops/anym/transformers/ValueTransformer.java
+++ b/cyclops-anym/src/main/java/com/oath/cyclops/anym/transformers/ValueTransformer.java
@@ -5,7 +5,7 @@ import java.util.function.*;
 import com.oath.cyclops.types.factory.Unit;
 import com.oath.cyclops.types.foldable.Folds;
 import com.oath.cyclops.types.MonadicValue;
-import com.oath.cyclops.types.Unwrapable;
+import com.oath.cyclops.types.Unwrappable;
 import com.oath.cyclops.types.Zippable;
 import cyclops.control.Option;
 import cyclops.data.tuple.Tuple2;
@@ -20,7 +20,7 @@ import cyclops.function.Function3;
 
 @Deprecated
 public abstract class ValueTransformer<W extends WitnessType<W>,T> implements Publisher<T>,
-  Unwrapable,
+  Unwrappable,
   Unit<T>,
   Folds<T>,
   Zippable<T> {

--- a/cyclops-anym/src/main/java/cyclops/monads/AnyM.java
+++ b/cyclops-anym/src/main/java/cyclops/monads/AnyM.java
@@ -25,7 +25,7 @@ import com.oath.cyclops.ReactiveConvertableSequence;
 import com.oath.cyclops.internal.stream.ReactiveStreamX;
 import com.oath.cyclops.types.Filters;
 import com.oath.cyclops.types.MonadicValue;
-import com.oath.cyclops.types.Unwrapable;
+import com.oath.cyclops.types.Unwrappable;
 
 import com.oath.cyclops.types.factory.EmptyUnit;
 import com.oath.cyclops.types.factory.Unit;
@@ -107,7 +107,7 @@ import static com.oath.cyclops.types.foldable.Evaluation.LAZY;
  *
  * @param <T> type data wrapped by the underlying monad
  */
-public interface AnyM<W extends WitnessType<W>,T> extends Unwrapable,
+public interface AnyM<W extends WitnessType<W>,T> extends Unwrappable,
                                                             To<AnyM<W,T>>,
                                                             EmptyUnit<T>,
                                                             Unit<T>,

--- a/cyclops-anym/src/main/java/cyclops/monads/AnyM2.java
+++ b/cyclops-anym/src/main/java/cyclops/monads/AnyM2.java
@@ -4,7 +4,7 @@ import com.oath.cyclops.anym.AnyMSeq;
 import com.oath.cyclops.anym.AnyMValue;
 import com.oath.cyclops.ReactiveConvertableSequence;
 import com.oath.cyclops.data.collections.extensions.IndexedSequenceX;
-import com.oath.cyclops.types.Unwrapable;
+import com.oath.cyclops.types.Unwrappable;
 
 import com.oath.cyclops.anym.extensability.MonadAdapter;
 import com.oath.cyclops.types.factory.EmptyUnit;
@@ -65,7 +65,7 @@ import static com.oath.cyclops.types.foldable.Evaluation.LAZY;
  * @param <T> type data wrapped by the underlying monad
  */
 public interface AnyM2<W extends WitnessType<W>,T2,T> extends   AnyM<W,T>,
-                                                                Unwrapable,
+                                                                Unwrappable,
                                                                 EmptyUnit<T>,
                                                                 Unit<T>,
                                                                 Folds<T>,

--- a/cyclops-reactive-collections/src/main/java/com/oath/cyclops/data/collections/extensions/CollectionX.java
+++ b/cyclops-reactive-collections/src/main/java/com/oath/cyclops/data/collections/extensions/CollectionX.java
@@ -6,7 +6,7 @@ import com.oath.cyclops.types.foldable.Evaluation;
 import com.oath.cyclops.types.functor.ReactiveTransformable;
 import com.oath.cyclops.types.persistent.PersistentCollection;
 import com.oath.cyclops.types.traversable.IterableX;
-import com.oath.cyclops.types.Unwrapable;
+import com.oath.cyclops.types.Unwrappable;
 import com.oath.cyclops.types.traversable.RecoverableTraversable;
 import cyclops.data.Seq;
 import cyclops.data.Vector;
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
  */
 public interface CollectionX<T> extends IterableX<T>,
                                         Collection<T> ,
-                                        Unwrapable,
+                                        Unwrappable,
                                         RecoverableTraversable<T>,
                                         ReactiveTransformable<T>,
                                         Unit<T> {

--- a/cyclops-reactive-collections/src/main/java/cyclops/reactive/collections/mutable/MapX.java
+++ b/cyclops-reactive-collections/src/main/java/cyclops/reactive/collections/mutable/MapX.java
@@ -2,7 +2,7 @@ package cyclops.reactive.collections.mutable;
 
 import com.oath.cyclops.ReactiveConvertableSequence;
 import com.oath.cyclops.data.collections.extensions.FluentMapX;
-import com.oath.cyclops.types.Unwrapable;
+import com.oath.cyclops.types.Unwrappable;
 import com.oath.cyclops.types.foldable.Folds;
 import com.oath.cyclops.types.foldable.To;
 import com.oath.cyclops.types.functor.BiTransformable;
@@ -35,7 +35,7 @@ import com.oath.cyclops.data.collections.extensions.standard.MapXImpl;
  * @param <K> Key type
  * @param <V> Value type
  */
-public interface MapX<K, V> extends To<MapX<K,V>>,Map<K, V>,Unwrapable, FluentMapX<K, V>, BiTransformable<K, V>, Transformable<V>, IterableFilterable<Tuple2<K, V>>, OnEmpty<Tuple2<K, V>>,
+public interface MapX<K, V> extends To<MapX<K,V>>,Map<K, V>, Unwrappable, FluentMapX<K, V>, BiTransformable<K, V>, Transformable<V>, IterableFilterable<Tuple2<K, V>>, OnEmpty<Tuple2<K, V>>,
     OnEmptySwitch<Tuple2<K, V>, Map<K, V>>, Publisher<Tuple2<K, V>>, Folds<Tuple2<K, V>>,ReactiveStreamsTerminalOperations<Tuple2<K,V>> {
 
 

--- a/cyclops/src/main/java/com/oath/cyclops/internal/stream/BaseExtendedStream.java
+++ b/cyclops/src/main/java/com/oath/cyclops/internal/stream/BaseExtendedStream.java
@@ -1,6 +1,6 @@
 package com.oath.cyclops.internal.stream;
 
-import com.oath.cyclops.types.Unwrapable;
+import com.oath.cyclops.types.Unwrappable;
 
 import com.oath.cyclops.util.ExceptionSoftener;
 
@@ -20,7 +20,7 @@ import java.util.stream.*;
 /**
  * Created by johnmcclean on 13/01/2017.
  */
-public abstract class BaseExtendedStream<T> implements Unwrapable, ReactiveSeq<T>, Iterable<T>  {
+public abstract class BaseExtendedStream<T> implements Unwrappable, ReactiveSeq<T>, Iterable<T>  {
 
     public abstract Stream<T> unwrapStream();
     @Override

--- a/cyclops/src/main/java/com/oath/cyclops/types/Unwrappable.java
+++ b/cyclops/src/main/java/com/oath/cyclops/types/Unwrappable.java
@@ -9,7 +9,7 @@ import java.util.function.Supplier;
  * @author johnmcclean
  *
  */
-public interface Unwrapable {
+public interface Unwrappable {
     /**
      * Unwrap a wrapped value
      *
@@ -28,8 +28,8 @@ public interface Unwrapable {
     }
     default <R> R unwrapNested(Class<?> c,Supplier<? extends R> supplier ){
         R unwrapped = unwrap();
-        while(unwrapped instanceof Unwrapable){
-            unwrapped = ((Unwrapable) unwrapped).unwrap();
+        while(unwrapped instanceof Unwrappable){
+            unwrapped = ((Unwrappable) unwrapped).unwrap();
         }
         if(c.isAssignableFrom(unwrapped.getClass())){
             return unwrapped;

--- a/cyclops/src/test/java/com/oath/cyclops/types/UnwrappableTest.java
+++ b/cyclops/src/test/java/com/oath/cyclops/types/UnwrappableTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.*;
 
-public class UnwrapableTest {
+public class UnwrappableTest {
     @Test
     public void unwrapIfInstanceHit() throws Exception {
        Object o = new MyUnWrappable().unwrapIfInstance(Either.class,()->"hello");
@@ -19,7 +19,7 @@ public class UnwrapableTest {
         Object o = new MyUnWrappable().unwrapIfInstance(String.class,()->"hello");
         assertThat(o,equalTo("hello"));
     }
-    static class MyUnWrappable implements Unwrapable{
+    static class MyUnWrappable implements Unwrappable {
         @Override
         public <R> R unwrap() {
             return (R) LazyEither.left("hello");


### PR DESCRIPTION
Hi,

I have renamed the `Unwrapable` interface to `Unwrappable` to fix #909.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
