### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ install: ./gradlew clean
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 script:
-  - travis_wait 120 ./gradlew assemble
-  - travis_wait 120 ./gradlew build jacoco --parallel --max-workers 4
+  - ./gradlew assemble
+  - ./gradlew build jacoco --parallel --max-workers 4
 
 before_cache:
     - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
